### PR TITLE
Fix touch inputs happening twice

### DIFF
--- a/src/components/Keyboard.jsx
+++ b/src/components/Keyboard.jsx
@@ -26,10 +26,10 @@ const Keyboard = ({ handleInput, letterStates }) => {
             <button
               key={key}
               className={getKeyClass(key)}
-              onTouchStart={(e) => handleTouch(e, key)}
+              onTouchEnd={(e) => handleTouch(e, key)}
               onClick={(e) => {
                 // Only handle click if it's not a touch event
-                if (!e.target.matches(':active')) {
+                if (e.type !== 'touchend') {
                   handleInput(key);
                 }
               }}


### PR DESCRIPTION
Update touch event handling in `src/components/Keyboard.jsx` to prevent duplicate inputs.

* Change `onTouchStart` to `onTouchEnd` in the `button` element to handle touch events.
* Update the `onClick` event to check if the event is a touch event before calling `handleInput`.

