### PR TITLE
Fix 'Congratulations' dialog to reflect correct number of tries

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,7 @@ function App() {
             targetWord={state.targetWord}
             handleShare={() => handleShare(state)}
             stats={stats}
+            currentRow={state.currentRow}
           />
         )}
 

--- a/src/components/GameOver.jsx
+++ b/src/components/GameOver.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const GameOver = ({ won, targetWord, handleShare, stats }) => {
+const GameOver = ({ won, targetWord, handleShare, stats, currentRow }) => {
   const handlePlayAgain = () => {
     // Only clear the game state, keep the stats
     localStorage.removeItem('wordleState');
@@ -17,7 +17,7 @@ const GameOver = ({ won, targetWord, handleShare, stats }) => {
         <div className="text-center mb-6">
           <p className="mb-2">
             {won 
-              ? `You found the word in ${stats.currentStreak} guesses!` 
+              ? `You found the word in ${currentRow} guesses!` 
               : `The word was: ${targetWord}`
             }
           </p>


### PR DESCRIPTION
Fixes #4

Update the "Congratulations" dialog to reflect the correct number of tries.

* Modify `src/components/GameOver.jsx` to accept a new prop `currentRow` and use it to display the number of guesses instead of `stats.currentStreak`.
* Update `src/App.jsx` to pass `state.currentRow` as a prop to the `GameOver` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jc9677/worldle/pull/5?shareId=dceaf468-e735-475c-9a30-6199e49d6118).