### PR TITLE
Fix keyboard color for letters in solution

### DIFF
--- a/src/hooks/useGameState.js
+++ b/src/hooks/useGameState.js
@@ -73,7 +73,7 @@ const useGameState = () => {
               newLetterStates[letter] = 'present';
             }
           } else {
-            if (!newLetterStates[letter]) {
+            if (!targetWord.includes(letter) && !newLetterStates[letter]) {
               newLetterStates[letter] = 'absent';
             }
           }


### PR DESCRIPTION
Fixes #6

Update `handleInput` function in `src/hooks/useGameState.js` to check if the letter is in the solution word before assigning the 'absent' state.

* Modify `newLetterStates` object to only assign 'absent' state if the letter is not in the solution word.
* Add condition to check if the letter is not in the target word before assigning 'absent' state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jc9677/worldle/pull/7?shareId=70b1c7b3-bd47-4091-9b13-febeb8f9d36e).